### PR TITLE
Video verification

### DIFF
--- a/conduit.c
+++ b/conduit.c
@@ -273,6 +273,7 @@ int processVideo(long in_videoID)
     sprintf(video_filename, "%s", PQgetvalue(db_result, 0, 0));
 
     FILE *fp;
+    FILE *mov;
     int status;
     char entry[MAXLEN];
     int entryCount = 0;
@@ -325,6 +326,7 @@ int processVideo(long in_videoID)
     if(entryCount == 0)
     {
       printf("<p>Uploaded video file could not be processed, video format not detected.<BR>");
+      remove(video_filename);
       exit(EXIT_FAILURE);
     }
 //    printf("<p> width is %d, height is %d, fps = %f, #frames is %d<BR>", frameWidth, frameHeight, fps, numFrames);
@@ -429,9 +431,15 @@ int processVideo(long in_videoID)
         printf("<p>System error. Please contact customer support<BR>");
         exit(EXIT_FAILURE);
       }
+    // move old video file into new directory
+    char* mov_dir = calloc(MAX_VIDEO_FILENAME_LENGTH, sizeof(char));
+    sprintf(mov_dir, "%s/%s", img_subdir, "oldvfile");
+    printf(" - %s - ", mov_dir);
+    rename(video_filename, mov_dir);
   }
   PQclear(db_result);
   PQfinish (db_connection);
+
   return 0;
 }
 

--- a/conduit.c
+++ b/conduit.c
@@ -436,6 +436,17 @@ int processVideo(long in_videoID)
     sprintf(mov_dir, "%s/%s", img_subdir, "oldvfile");
     printf(" - %s - ", mov_dir);
     rename(video_filename, mov_dir);
+    parameter_values[0] = mov_dir;
+    parameter_values[1] = video_ID;
+
+    strncpy(&db_statement[0], "UPDATE VIDEO_METADATA SET SRC_VIDEO_FILE=$1 WHERE VIDEO_ID=$2", MAX_DB_STATEMENT_BUFFER_LENGTH);
+    db_result = PQexecParams(db_connection, db_statement, 2, NULL, parameter_values, NULL, NULL, 0);
+    
+    if(PQresultStatus(db_result) != PGRES_COMMAND_OK)
+    {
+      printf("<p>System error. Please contact customer service.<DB>");
+      exit(EXIT_FAILURE);
+    }
   }
   PQclear(db_result);
   PQfinish (db_connection);


### PR DESCRIPTION
-bad video formats are deleted from server immediately
-after video conversion is completed, it is moved into the video_id directory
-the path is updated to reflect this in the database